### PR TITLE
kmodloader: add general support for built-in modules and modinfo

### DIFF
--- a/kmodloader.c
+++ b/kmodloader.c
@@ -311,12 +311,13 @@ static int scan_loaded_modules(void)
 {
 	size_t buf_len = 0;
 	char *buf = NULL;
+	int rv = -1;
 	FILE *fp;
 
 	fp = fopen("/proc/modules", "r");
 	if (!fp) {
 		ULOG_ERR("failed to open /proc/modules\n");
-		return -1;
+		goto out;
 	}
 
 	while (getline(&buf, &buf_len, fp) > 0) {
@@ -338,16 +339,18 @@ static int scan_loaded_modules(void)
 		}
 		if (!n) {
 			ULOG_ERR("Failed to allocate memory for module\n");
-			return -1;
+			goto out;
 		}
 
 		n->usage = m.usage;
 		n->state = LOADED;
 	}
+	rv = 0;
+out:
 	free(buf);
 	fclose(fp);
 
-	return 0;
+	return rv;
 }
 
 static struct module* get_module_info(const char *module, const char *name)

--- a/kmodloader.c
+++ b/kmodloader.c
@@ -431,12 +431,10 @@ out:
 static int scan_module_folder(const char *dir)
 {
 	int gl_flags = GLOB_NOESCAPE | GLOB_MARK;
-	struct utsname ver;
 	char *path;
 	glob_t gl;
 	int j, rv = 0;
 
-	uname(&ver);
 	path = alloca(strlen(dir) + sizeof("*.ko") + 1);
 	sprintf(path, "%s*.ko", dir);
 


### PR DESCRIPTION
### Maintainer: @blogic 

Description
---
This series fixes some long-standing pain/annoyance points with OpenWrt around inconsistent handling between loadable and built-in modules. This is in contrast to mainstream distros, where `modprobe`, `modinfo`, `rmmod`, etc, are aware of built-in module metadata e.g. `modprobe -q <module>` can be used to test the presence of a built-in or loadable module equally. Current `kmodloader` also ignores parameter details already encoded in OpenWrt kernel modules.

The main changes made in the series are:
1. Teach `print_modinfo()` to understand and show parameters included in current modules' `.modinfo` sections.
2. Add `scan_builtin_modules()` to parse `modules.builtin` file if present, and use it for consistent presence-testing with `modprobe` or improved logging e.g. `rmmod <module-builtin>`.
3. Update code to parse `modules.builtin.modinfo` file in `get_module_info()`, `scan_builtin_modules()` and `print_modinfo()`. This allows usage of aliases for builtin modules, and enables `modinfo` to print basic details of built-in modules.
4. Clean up and factor out some duplicated `mmap()` related code.
5. Fix a small memory leak introduced in 4c7b720b9c63b826fb9404e454ae54f2ef5649d5.

Related
---
A separate OpenWrt PR includes files `modules.builtin` and `modules.builtin.modinfo` into the `kernel` package for use by `kmodloader` (https://github.com/openwrt/openwrt/pull/14218) and has since been merged. These PRs are complementary but independent since `kmodloader` will work with/without the files above.

Testing
--- 

- Compile and run-tested on both Ubuntu (Ubuntu 22.04 LTS) and Openwrt (master, malta/mipseb32)
- Verified behaviour of `modprobe`, `modinfo`, `rmmod` against built-in and loadable modules, with and without varying types of parameters.
- Compared behaviour, output and error messages between distros above.
- Confirmed `kmodloader` continues to function without `modules.builtin` and `modules.builtin.modinfo`.
- Examples of usage and changed behaviour are included in commit messages.
- Checked size impact of changes: updates to `kmodloader`, with inclusion of `modules.builtin` and `modules.builtin.modinfo`, increased OpenWrt compressed filesystem image size by ~2.5 KB.

Review
-
CC previous contributors: @nbd168 @hauke @Ansuel @neheb @yousong 
Thanks in advance for your feedback...