### PR TITLE
kmodloader: fix invalid read outside mapped region

### DIFF
--- a/kmodloader.c
+++ b/kmodloader.c
@@ -437,12 +437,13 @@ static struct module* get_module_info(const char *module, const char *name)
 
 	strings = map + offset;
 	while (true) {
+		char *end = map + offset + size;
 		char *sep;
 		int len;
 
-		while (!strings[0])
+		while ((strings < end) && !strings[0])
 			strings++;
-		if (strings >= map + offset + size)
+		if (strings >= end)
 			break;
 		if (is_builtin) {
 			sep = strstr(strings, ".");
@@ -624,13 +625,14 @@ static int print_modinfo(const struct module *m)
 		printf("name:\t\t%s\n", m->name);
 	printf("filename:\t%s\n", is_builtin ? "(builtin)" : mpath);
 	while (true) {
+		char *end = map + offset + size;
 		char *pname, *pdata;
 		char *dup = NULL;
 		char *sep, *sep2;
 
-		while (!strings[0])
+		while ((strings < end) && !strings[0])
 			strings++;
-		if (strings >= map + offset + size)
+		if (strings >= end)
 			break;
 		if (is_builtin) {
 			sep = strstr(strings, ".");


### PR DESCRIPTION
Code parsing .modinfo data skips over null sequences without checking bounds and may read past mapped memory, potentially triggering SIGSEGV.

Fixes: d6e6825c4697 ("add support for module handling")
Refer: 9371411715c8 ("kmodloader: fix out-of-bound access when parsing .modinfo")

@ynezz @Ansuel This fixes a potential SIGSEGV, and might help with https://github.com/openwrt/openwrt/issues/14463. Validated using Valgrind.