### PR TITLE
kmodloader: fix memory leaks and invalid write, improve cleanup and modinfo output

### DIFF
--- a/kmodloader.c
+++ b/kmodloader.c
@@ -282,8 +282,10 @@ alloc_module_node(const char *name, struct module *m, bool is_alias)
 		mn->avl.key = strcpy(_name, name);
 		mn->m = m;
 		mn->is_alias = is_alias;
-		avl_insert(&modules, &mn->avl);
-		m->refcnt += 1;
+		if (avl_insert(&modules, &mn->avl) == 0)
+			m->refcnt += 1;
+		else
+			free(mn);
 	}
 	return mn;
 }

--- a/kmodloader.c
+++ b/kmodloader.c
@@ -892,7 +892,7 @@ static int print_usage(char *arg)
 
 static int main_insmod(int argc, char **argv)
 {
-	char *name, *cur, *options = NULL;
+	char *name, *path, *cur, *opts = NULL;
 	int i, ret = -1, len;
 
 	if (argc < 2)
@@ -913,19 +913,19 @@ static int main_insmod(int argc, char **argv)
 
 	}
 
-	for (len = 0, i = 2; i < argc; i++)
+	for (len = 1, i = 2; i < argc; i++)
 		len += strlen(argv[i]) + 1;
 
-	options = malloc(len);
-	if (!options) {
+	opts = malloc(len);
+	if (!opts) {
 		ULOG_ERR("out of memory\n");
 		goto err;
 	}
 
-	options[0] = 0;
-	cur = options;
+	opts[0] = 0;
+	cur = opts;
 	for (i = 2; i < argc; i++) {
-		if (options[0]) {
+		if (opts[0]) {
 			*cur = ' ';
 			cur++;
 		}
@@ -937,19 +937,18 @@ static int main_insmod(int argc, char **argv)
 		goto err;
 	}
 
-	if (get_module_path(argv[1])) {
-		name = argv[1];
-	} else if (!get_module_path(name)) {
+	if (!(path = get_module_path(argv[1])) ||
+	     (path = get_module_path(name))) {
 		fprintf(stderr, "Failed to find %s. Maybe it is a built in module ?\n", name);
 		goto err;
 	}
 
-	ret = insert_module(get_module_path(name), options);
+	ret = insert_module(path, opts);
 	if (ret)
 		ULOG_ERR("failed to insert %s\n", get_module_path(name));
 
 err:
-	free(options);
+	free(opts);
 	free_modules();
 	free_module_folders();
 


### PR DESCRIPTION
### Maintainer: @blogic 

Description
---
This patch series addresses some `kmodloader` problems highlighted during testing with Valgrind, and includes the following fixes and improvements:
1. Add missing calls to free modules and related data structures during cleanup, and ensure that resources are consistently freed on exit paths. This simplifies memory accounting and audit.
2. Fix an invalid write to a zero-size memory block.
3. Fix a direct memory leak on failure of  `avl_instert()`.
4. Enable duplicate avl-tree keys to fix an indirect memory leak and improve `modinfo` output details.

Testing
---
- Compile and run-tested on Ubuntu (Ubuntu 22.04 LTS) and Openwrt QEMU (master, malta/mipseb32 and armsr/32)
- Verified behaviour of `modprobe`, `modinfo`, `rmmod`, `insmod` against built-in and loadable modules.
- Validated memory management of above applets using Valgrind.

Review
---
CC: (previous review) @Ansuel  and (past contributors) @nbd168 @hauke @yousong 
Thanks in advance for any feedback...