### PR TITLE
ubox validate: port range check fix

### DIFF
--- a/validate/validate.c
+++ b/validate/validate.c
@@ -597,8 +597,10 @@ dt_type_portrange(struct dt_state *s, int nargs)
 
 	n = strtoul(s->value, &e, 10);
 
-	if (e == s->value || *e != '-')
-		return false;
+	if (e == s->value || *e != '-') {
+		// If parsing as portrange fails, try parsing as a single port
+		return dt_type_port(s, nargs);
+	}
 
 	m = strtoul(e + 1, &e, 10);
 


### PR DESCRIPTION
The luci GUI allows a single port in a port range field. This additional check validates a single port if a range was not found.


ping @jow- @blogic @nbd168 